### PR TITLE
add simple term storage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,5 @@ erl_crash.dump
 
 # Also ignore archive artifacts (built via "mix archive.build").
 *.ez
+
+test/tmp

--- a/README.md
+++ b/README.md
@@ -119,16 +119,16 @@ config :system_registry, SystemRegistry.Processor.Config,
 ```
 
 If priorities are not declared in the application config, the default priority
-levels `[:debug, :_, :default]` will be used.
+levels `[:debug, :_, :persistence, :default]` will be used.
 
 Options can be passed in when starting a transaction, or when using `update` / `delete` directly.
 
 ```elixir
 # Pass as options
-SystemRegistry.update([:config, root, :a], 1, priority: :high)
+SystemRegistry.update([:config, :a], 1, priority: :high)
 # Or
 SystemRegistry.transaction(priority: :high)
-|> SystemRegistry.update([:config, root, :a], 1)
+|> SystemRegistry.update([:config, :a], 1)
 |> SystemRegistry.commit
 ```
 
@@ -140,6 +140,30 @@ The mount point for the `Config` processor defaults to `:config`, but can be con
 config :system_registry, SystemRegistry.Processor.Config,
   mount: :somewhere_else
 ```
+
+**Persistence**
+
+Config values can be persisted using the term storage module. Persistence is enabled
+for individual leaf nodes. The value for the leaf node is written to a file at the
+scope specified. For example, lets say we want to persist the value for the leaf node
+`[:config, :a]`. In the application that wants to persist this value, we would call:
+`SystemRegistry.TermStorage.persist([:config, :a])`. This cal would typically be made
+in the dependencies application start. Once persistence is enabled, term storage will
+make its own entry into the config with the value from disk using the priority
+`:persistence`. Using this technique, old values will remain saved on the file system
+but they will not be made available unless they are told to be persisted. Scopes to be
+persisted and the path to write persisted terms to can be set in the application config
+
+```elixir
+config :system_registry, SystemRegistry.TermStorage,
+  scopes: [
+    [:config, :network_interface, "wlan0", :ssid],
+    [:config, :network_interface, "wlan0", :psk],
+  ],
+  path: "/tmp/system_registry"
+```
+
+The default path for term storage is at `/tmp/system_registry`
 
 ### Dispatch API
 

--- a/config/config.exs
+++ b/config/config.exs
@@ -1,3 +1,9 @@
 # This file is responsible for configuring your application
 # and its dependencies with the aid of the Mix.Config module.
 use Mix.Config
+
+config :system_registry, SystemRegistry.TermStorage,
+  scopes: [
+    [:config, :a]
+  ],
+  path: File.cwd!() |> Path.join("test/tmp") |> Path.expand

--- a/lib/system_registry/application.ex
+++ b/lib/system_registry/application.ex
@@ -21,6 +21,8 @@ defmodule SystemRegistry.Application do
       Application.get_env(:system_registry, SystemRegistry.Processor.Config)
     state_opts =
       Application.get_env(:system_registry, SystemRegistry.Processor.State)
+    term_storage_opts =
+      Application.get_env(:system_registry, SystemRegistry.TermStorage)
 
     workers = [
       worker(SystemRegistry.Local, []),
@@ -28,6 +30,7 @@ defmodule SystemRegistry.Application do
       worker(SystemRegistry.Registration, []),
       worker(SystemRegistry.Processor.State, [state_opts]),
       worker(SystemRegistry.Processor.Config, [config_opts]),
+      worker(SystemRegistry.TermStorage, [term_storage_opts])
     ]
 
     # See http://elixir-lang.org/docs/stable/elixir/Supervisor.html

--- a/lib/system_registry/processor/config.ex
+++ b/lib/system_registry/processor/config.ex
@@ -98,7 +98,7 @@ defmodule SystemRegistry.Processor.Config do
   end
 
   defp default_priorities() do
-    [:debug, :_, :default]
+    [:debug, :_, :persistence, :default]
   end
 
 end

--- a/lib/system_registry/term_storage.ex
+++ b/lib/system_registry/term_storage.ex
@@ -1,0 +1,110 @@
+defmodule SystemRegistry.TermStorage do
+  @moduledoc """
+  Values can be persisted using the term storage module. Persistence is enabled
+  for individual leaf nodes. The value for the leaf node is written to a file at the
+  scope specified. For example, lets say we want to persist the value for the leaf node
+  `[:config, :a]`. In the application that wants to persist this value, we would call:
+  `SystemRegistry.TermStorage.persist([:config, :a])`. This cal would typically be made
+  in the dependencies application start. Once persistence is enabled, term storage will
+  make its own entry into the config with the value from disk using the priority
+  `:persistence`. Using this technique, old values will remain saved on the file system
+  but they will not be made available unless they are told to be persisted. Scopes to be
+  persisted and the path to write persisted terms to can be set in the application config
+
+  ```elixir
+  config :system_registry, SystemRegistry.TermStorage,
+    scopes: [
+      [:config, :network_interface, "wlan0", :ssid],
+      [:config, :network_interface, "wlan0", :psk],
+    ],
+    path: "/tmp/system_registry"
+  ```
+  """
+
+  use GenServer
+
+  @spec start_link(opts :: term) ::
+    {:ok, pid} | {:error, reason :: term}
+  @doc """
+  Starts the TermStorage server
+  """
+  def start_link(opts \\ []) do
+    GenServer.start_link(__MODULE__, opts, name: __MODULE__)
+  end
+
+  @spec persist(SystemRegistry.scope) :: :ok
+  @doc """
+  A scope to a leaf node to be persisted upon change.
+
+  For Example:
+    Lets say that we want to make sure that the ssid for our wireless
+    network is persisted between reboots.
+    `SystemRegistry.TermStorage.persist([:config, :network_interface, "wlan0", :ssid])``
+  """
+  def persist(scope) do
+    GenServer.call(__MODULE__, {:persist, scope})
+  end
+
+  # GenServer Callbacks
+
+  def init(opts) do
+    scopes = opts[:scopes] || []
+    path = opts[:path] || "/tmp/system_registry"
+    SystemRegistry.register()
+    {:ok, %{
+      scopes: scopes,
+      values: [],
+      path: path
+    }}
+  end
+
+  def handle_call({:persist, scope}, _from, s) do
+    if value = get_value(s.path, scope) do
+      SystemRegistry.update(scope, value, priority: :persistence)
+    end
+    {:reply, :ok, %{s | scopes: [scope | s.scopes]}}
+  end
+
+  def handle_info({:system_registry, :global, reg}, s) do
+    values =
+      Enum.reduce(s.scopes, [], fn(scope, acc) ->
+        old =
+          case Enum.find(s.values, fn({v, _}) -> v == scope end) do
+            nil -> nil
+            {_, v} -> v
+          end
+        value = get_in(reg, scope)
+        if value != old do
+          put_value(s.path, scope, value)
+        end
+        [{scope, value} | acc]
+      end)
+    {:noreply, %{s | values: values}}
+  end
+
+  defp put_value(path, scope, value) do
+    SystemRegistry.update(scope, value, priority: :persistence)
+
+    path = path(path, scope)
+    path
+    |> Path.dirname()
+    |> File.mkdir_p()
+
+    File.write!(path, :erlang.term_to_binary(value))
+  end
+
+
+  defp get_value(path, scope) do
+    path = path(path, scope)
+    case File.read(path) do
+      {:ok, file} ->
+        :erlang.binary_to_term(file) || nil
+      _ -> nil
+    end
+  end
+
+  defp path(path, scope) do
+    scope = Enum.map(scope, &to_string/1)
+    Path.join([path] ++ scope)
+  end
+end


### PR DESCRIPTION
Simple term storage will persist the value of specified leaf nodes and make their values available between vm boots. Its is a very simple mechanism which writes the value of a leaf to a file.